### PR TITLE
Refactor to HTML-based UI with per-user audio controls

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,15 @@ This project provides a one-button WebRTC audio call with automatic
 localhost.run tunnelling. The codebase is now organised into several
 modules to make future extensions easier.
 
+The browser interface lives in `static/index.html` with styles in
+`static/style.css`.  Each participant adjusts their own microphone and
+playback volume locally in the page; these controls do not affect other
+users.
+
+The application icon is provided as `static/icon.svg`.  When building an
+executable (e.g. with PyInstaller), supply this icon to give the program a
+glassmorphic neon look.
+
 Run the application:
 
 ```bash

--- a/gui.py
+++ b/gui.py
@@ -3,14 +3,12 @@
 import os
 import time
 import tkinter as tk
-from tkinter import simpledialog
 import webbrowser
 
 from async_runner import AsyncRunner
 from core import (
     HTTP_PORT,
     PeerContext,
-    AUDIO_SETTINGS,
     get_local_ip,
     run_peer,
     udp_discover,
@@ -28,22 +26,29 @@ class App:
 
         self.root.title("Secure Call — WebRTC")
 
-        # Ask for name and mode at startup
-        self.call_mode = simpledialog.askstring(
-            "Режим",
-            "Введите режим: 1x1 или group",
-            parent=root,
-        ) or "1x1"
-        self.username = simpledialog.askstring(
-            "Ваше имя",
-            "Введите своё имя",
-            parent=root,
-        ) or "Anonymous"
+        self.call_mode = "1x1"
+        self.username = ""
+        self._choose_mode()
 
-        wrap = tk.Frame(root)
+    def _choose_mode(self) -> None:
+        win = tk.Toplevel(self.root)
+        win.title("Выбор режима")
+        tk.Label(win, text="Выберите режим").pack(padx=20, pady=10)
+
+        def set_mode(mode: str) -> None:
+            self.call_mode = mode
+            win.destroy()
+
+        tk.Button(win, text="1x1 call", width=15, command=lambda: set_mode("1x1")).pack(pady=5)
+        tk.Button(win, text="Group call", width=15, command=lambda: set_mode("group")).pack(pady=5)
+
+        win.grab_set()
+        self.root.wait_window(win)
+
+        wrap = tk.Frame(self.root)
         wrap.pack(padx=10, pady=10)
 
-        tk.Label(wrap, text=f"Пользователь: {self.username} | режим: {self.call_mode}").pack(pady=(0, 6))
+        tk.Label(wrap, text=f"Режим: {self.call_mode}").pack(pady=(0, 6))
 
         tk.Label(
             wrap,
@@ -67,22 +72,6 @@ class App:
 
         self.status = tk.Label(wrap, text="Сервер запущен, туннель стартует…", fg="green")
         self.status.pack(pady=(8, 0))
-
-        # audio controls
-        ctl = tk.LabelFrame(wrap, text="Звук")
-        ctl.pack(pady=(10, 0), fill="x")
-
-        self.mic_var = tk.DoubleVar(value=100)
-        self.mic_mute = tk.IntVar()
-        tk.Label(ctl, text="Микрофон").grid(row=0, column=0, sticky="w")
-        tk.Scale(ctl, from_=0, to=100, orient="horizontal", variable=self.mic_var, command=self._upd_mic).grid(row=0, column=1)
-        tk.Checkbutton(ctl, text="Mute", variable=self.mic_mute, command=self._upd_mic).grid(row=0, column=2)
-
-        self.remote_var = tk.DoubleVar(value=100)
-        self.remote_mute = tk.IntVar()
-        tk.Label(ctl, text="Собеседник").grid(row=1, column=0, sticky="w")
-        tk.Scale(ctl, from_=0, to=100, orient="horizontal", variable=self.remote_var, command=self._upd_remote).grid(row=1, column=1)
-        tk.Checkbutton(ctl, text="Mute", variable=self.remote_mute, command=self._upd_remote).grid(row=1, column=2)
 
     def set_tunnel_url(self, url: str) -> None:
         """Display the public tunnel URL as a clickable link."""
@@ -131,14 +120,4 @@ class App:
             self.root.after(0, lambda: self.status.config(text=text, fg=color))
         except Exception:
             self.status.config(text=text, fg=color)
-
-    # --- audio controls -------------------------------------------------
-
-    def _upd_mic(self, _evt=None) -> None:
-        AUDIO_SETTINGS.mic_volume = self.mic_var.get() / 100.0
-        AUDIO_SETTINGS.mic_muted = bool(self.mic_mute.get())
-
-    def _upd_remote(self, _evt=None) -> None:
-        AUDIO_SETTINGS.remote_volume = self.remote_var.get() / 100.0
-        AUDIO_SETTINGS.remote_muted = bool(self.remote_mute.get())
 

--- a/main.py
+++ b/main.py
@@ -2,6 +2,7 @@
 
 import threading
 import tkinter as tk
+from pathlib import Path
 
 from async_runner import AsyncRunner
 from core import HTTP_PORT, log, start_http_server, start_udp_responder
@@ -17,6 +18,11 @@ def main() -> None:
     log.info("[BOOT] HTTP server scheduled, UDP responder started")
 
     root = tk.Tk()
+    try:
+        icon_path = Path(__file__).resolve().parent / "static" / "icon.svg"
+        root.iconphoto(True, tk.PhotoImage(file=icon_path))
+    except Exception:
+        pass
     app = App(root, runner)
 
     threading.Thread(

--- a/static/icon.svg
+++ b/static/icon.svg
@@ -1,0 +1,13 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 128 128">
+  <defs>
+    <filter id="glow" x="-50%" y="-50%" width="200%" height="200%">
+      <feGaussianBlur stdDeviation="3" result="coloredBlur"/>
+      <feMerge>
+        <feMergeNode in="coloredBlur"/>
+        <feMergeNode in="SourceGraphic"/>
+      </feMerge>
+    </filter>
+  </defs>
+  <rect x="8" y="8" width="112" height="112" rx="24" fill="#0ff" fill-opacity="0.1" filter="url(#glow)"/>
+  <text x="64" y="82" font-size="56" text-anchor="middle" fill="#0ff" font-family="sans-serif">SC</text>
+</svg>

--- a/static/index.html
+++ b/static/index.html
@@ -1,0 +1,197 @@
+<!doctype html>
+<html lang="ru">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width,initial-scale=1" />
+<title>Secure Call — WebRTC (Browser)</title>
+<link rel="icon" type="image/svg+xml" href="/icon.svg" />
+<link rel="stylesheet" href="/style.css" />
+</head>
+<body>
+<div class="card">
+  <h1>Secure Call — WebRTC (Browser)</h1>
+  <div class="row">
+    <input id="name" type="text" placeholder="Ваше имя" />
+  </div>
+  <div class="row">
+    <button id="btn">Подключиться</button>
+    <span id="st" class="mono"></span>
+  </div>
+  <div class="row">
+    <label><input type="checkbox" id="ec" checked> Echo Cancellation</label>
+    <label><input type="checkbox" id="ns" checked> Noise Suppression</label>
+    <label><input type="checkbox" id="agc" checked> Auto Gain</label>
+  </div>
+  <div class="row">
+    <label>Микрофон <input type="range" id="micVol" min="0" max="100" value="100"></label>
+    <label><input type="checkbox" id="micMute"> Mute</label>
+  </div>
+  <div class="row">
+    <label>Собеседник <input type="range" id="remoteVol" min="0" max="100" value="100"></label>
+    <label><input type="checkbox" id="remoteMute"> Mute</label>
+  </div>
+  <audio id="remote" autoplay playsinline></audio>
+  <div id="log" class="row mono" style="white-space:pre-wrap;"></div>
+  <div class="help">
+    Открывайте эту страницу через публичный HTTPS-домен туннеля — сигналинг будет WSS, а медиа пойдёт напрямую (или через TURN).
+  </div>
+</div>
+<script>
+(() => {
+  const logEl = document.getElementById('log');
+  const statusEl = document.getElementById('st');
+  const btn = document.getElementById('btn');
+  const audioEl = document.getElementById('remote');
+  const nameEl = document.getElementById('name');
+  const micVolEl = document.getElementById('micVol');
+  const micMuteEl = document.getElementById('micMute');
+  const remoteVolEl = document.getElementById('remoteVol');
+  const remoteMuteEl = document.getElementById('remoteMute');
+
+  let micGain;
+  let localTrack;
+
+  const opts = () => ({
+    audio: {
+      channelCount: 1,
+      noiseSuppression: document.getElementById('ns').checked,
+      echoCancellation: document.getElementById('ec').checked,
+      autoGainControl: document.getElementById('agc').checked,
+      sampleRate: 48000
+    },
+    video: false
+  });
+
+  const say = (m, cls='') => { if (cls) statusEl.className = cls; statusEl.textContent = m; logEl.textContent += m + '\n'; };
+
+  function filterCandidateStr(cand) {
+    if (cand.includes(' 127.') || cand.includes(' 169.254.') || cand.includes(' 192.168.56.')) return false;
+    return true;
+  }
+
+  const wsScheme = (location.protocol === 'https:') ? 'wss://' : 'ws://';
+  const wsURL = wsScheme + location.host + '/ws';
+
+  function parseIceFromEnv() {
+    try { return JSON.parse(window.ICE_URLS || "[]"); } catch { return []; }
+  }
+  const defaultIce = [{urls: 'stun:stun.l.google.com:19302'}];
+  const iceServers = (parseIceFromEnv().length ? parseIceFromEnv() : defaultIce);
+
+  async function connect() {
+    btn.disabled = true;
+    say('Инициализация…', 'mono');
+
+    const pc = new RTCPeerConnection({iceServers});
+    const ws = new WebSocket(wsURL);
+
+    pc.onicecandidate = ev => {
+      if (!ev.candidate) {
+        (ws.readyState === 1) && ws.send(JSON.stringify({type:'ice', candidate: null}));
+        return;
+      }
+      const cand = ev.candidate.candidate || '';
+      if (!filterCandidateStr(cand)) { say('[ICE] drop ' + cand); return; }
+      (ws.readyState === 1) && ws.send(JSON.stringify({
+        type: 'ice',
+        candidate: {
+          candidate: cand,
+          sdpMid: ev.candidate.sdpMid,
+          sdpMLineIndex: ev.candidate.sdpMLineIndex
+        }
+      }));
+    };
+
+    pc.ontrack = ev => {
+      say('[PC] ontrack audio', 'ok');
+      audioEl.srcObject = ev.streams[0] || new MediaStream([ev.track]);
+      audioEl.play().catch(()=>{});
+    };
+    pc.onconnectionstatechange   = () => say('[PC] state=' + pc.connectionState);
+    pc.oniceconnectionstatechange= () => say('[ICE] state=' + pc.iceConnectionState);
+
+    try {
+      const ms = await navigator.mediaDevices.getUserMedia(opts());
+      const ctx = new (window.AudioContext || window.webkitAudioContext)();
+      const src = ctx.createMediaStreamSource(ms);
+      micGain = ctx.createGain();
+      const dst = ctx.createMediaStreamDestination();
+      src.connect(micGain).connect(dst);
+      localTrack = dst.stream.getAudioTracks()[0];
+      pc.addTrack(localTrack, dst.stream);
+      say('[MEDIA] mic ok');
+    } catch (err) {
+      say('Микрофон не доступен: ' + err.name + ' — добавляю recvonly', 'warn');
+      pc.addTransceiver('audio', { direction: 'recvonly' });
+    }
+
+    ws.onopen = () => {
+      say('[WS] open', 'ok');
+      const n = nameEl.value.trim();
+      if (n) ws.send(JSON.stringify({type:'name', name: n}));
+    };
+    ws.onerror = () => say('[WS] error', 'err');
+    ws.onclose = () => say('[WS] closed', 'warn');
+
+    ws.onmessage = async (ev) => {
+      const data = JSON.parse(ev.data);
+      if (data.type === 'joined') {
+        const peers = data.peers || 1;
+        const isCaller = (peers >= 2);
+        say(`[WS] joined, peers=${peers}`);
+        if (isCaller) {
+          const offer = await pc.createOffer();
+          await pc.setLocalDescription(offer);
+          ws.send(JSON.stringify({type:'offer', sdp: offer.sdp, sdpType: offer.type}));
+          say('[PC] offer sent');
+        } else {
+          say('[PC] waiting for offer…');
+        }
+      } else if (data.type === 'offer') {
+        say('[WS] got offer');
+        await pc.setRemoteDescription({type:'offer', sdp: data.sdp});
+        const answer = await pc.createAnswer();
+        await pc.setLocalDescription(answer);
+        ws.send(JSON.stringify({type:'answer', sdp: answer.sdp, sdpType: answer.type}));
+        say('[PC] answer sent');
+      } else if (data.type === 'answer') {
+        say('[WS] got answer');
+        await pc.setRemoteDescription({type:'answer', sdp: data.sdp});
+      } else if (data.type === 'ice') {
+        const c = data.candidate;
+        if (c && c.candidate && filterCandidateStr(c.candidate)) {
+          try { await pc.addIceCandidate(c); } catch {}
+        } else if (c === null) {
+          try { await pc.addIceCandidate(null); } catch {}
+        }
+      } else if (data.type === 'full') {
+        say('[WS] room full', 'err');
+      }
+    };
+
+    const updMic = () => {
+      if (!micGain) return;
+      const vol = micMuteEl.checked ? 0 : (micVolEl.value / 100);
+      micGain.gain.value = vol;
+      if (localTrack) localTrack.enabled = !micMuteEl.checked;
+    };
+    micVolEl.addEventListener('input', updMic);
+    micMuteEl.addEventListener('change', updMic);
+
+    const updRemote = () => {
+      audioEl.volume = remoteMuteEl.checked ? 0 : (remoteVolEl.value / 100);
+      audioEl.muted = remoteMuteEl.checked;
+    };
+    remoteVolEl.addEventListener('input', updRemote);
+    remoteMuteEl.addEventListener('change', updRemote);
+    updRemote();
+  }
+
+  document.getElementById('btn').addEventListener('click', async () => {
+    try { await connect(); }
+    catch (e) { say('Ошибка: ' + e, 'err'); document.getElementById('btn').disabled = false; }
+  });
+})();
+</script>
+</body>
+</html>

--- a/static/style.css
+++ b/static/style.css
@@ -1,0 +1,44 @@
+body {
+  font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif;
+  background: linear-gradient(135deg, #091921, #000);
+  color: #fff;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 100vh;
+  margin: 0;
+}
+.card {
+  background: rgba(255, 255, 255, 0.1);
+  border-radius: 16px;
+  padding: 24px;
+  backdrop-filter: blur(12px);
+  box-shadow: 0 0 20px rgba(0, 255, 255, 0.4);
+  max-width: 720px;
+  width: 100%;
+}
+button {
+  padding: 10px 16px;
+  border-radius: 10px;
+  border: 1px solid rgba(0,255,255,0.6);
+  background: rgba(0,0,0,0.3);
+  color: #0ff;
+  cursor: pointer;
+}
+button:disabled {
+  opacity: 0.6;
+  cursor: default;
+}
+.row { margin: 10px 0; }
+.mono { font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace; }
+label { margin-right: 12px; }
+input[type="text"] {
+  padding: 8px 12px;
+  border-radius: 8px;
+  border: 1px solid rgba(0,255,255,0.6);
+  background: rgba(0,0,0,0.3);
+  color: #0ff;
+}
+input[type="range"] {
+  width: 120px;
+}


### PR DESCRIPTION
## Summary
- Serve browser UI from separate HTML/CSS files with neon glassmorphic design
- Add per-user microphone and playback controls in the web client
- Select launch mode via Tk buttons and load new SVG app icon

## Testing
- `python -m py_compile *.py`


------
https://chatgpt.com/codex/tasks/task_e_68a6273e9e60832794be02a69274030b