### PR TITLE
feat: add discord-like controls

### DIFF
--- a/static/index.html
+++ b/static/index.html
@@ -14,7 +14,8 @@
     <input id="name" type="text" placeholder="Ваше имя" />
   </div>
   <div class="row">
-    <button id="btn">Подключиться</button>
+    <button id="btn" class="primary">Подключиться</button>
+    <button id="bye" class="danger" disabled>Отключиться</button>
     <span id="st" class="mono"></span>
   </div>
   <div class="row">
@@ -41,6 +42,7 @@
   const logEl = document.getElementById('log');
   const statusEl = document.getElementById('st');
   const btn = document.getElementById('btn');
+  const bye = document.getElementById('bye');
   const audioEl = document.getElementById('remote');
   const nameEl = document.getElementById('name');
   const micVolEl = document.getElementById('micVol');
@@ -50,6 +52,8 @@
 
   let micGain;
   let localTrack;
+  let pc;
+  let ws;
 
   const opts = () => ({
     audio: {
@@ -80,10 +84,11 @@
 
   async function connect() {
     btn.disabled = true;
+    bye.disabled = false;
     say('Инициализация…', 'mono');
 
-    const pc = new RTCPeerConnection({iceServers});
-    const ws = new WebSocket(wsURL);
+    pc = new RTCPeerConnection({iceServers});
+    ws = new WebSocket(wsURL);
 
     pc.onicecandidate = ev => {
       if (!ev.candidate) {
@@ -131,7 +136,11 @@
       if (n) ws.send(JSON.stringify({type:'name', name: n}));
     };
     ws.onerror = () => say('[WS] error', 'err');
-    ws.onclose = () => say('[WS] closed', 'warn');
+    ws.onclose = () => {
+      say('[WS] closed', 'warn');
+      btn.disabled = false;
+      bye.disabled = true;
+    };
 
     ws.onmessage = async (ev) => {
       const data = JSON.parse(ev.data);
@@ -186,11 +195,20 @@
     remoteMuteEl.addEventListener('change', updRemote);
     updRemote();
   }
+  function disconnect() {
+    if (pc) { try { pc.close(); } catch {} pc = null; }
+    if (ws && ws.readyState <= 1) { try { ws.close(); } catch {} }
+    if (localTrack) { try { localTrack.stop(); } catch {} localTrack = null; }
+    btn.disabled = false;
+    bye.disabled = true;
+    say('[APP] disconnected', 'warn');
+  }
 
   document.getElementById('btn').addEventListener('click', async () => {
     try { await connect(); }
-    catch (e) { say('Ошибка: ' + e, 'err'); document.getElementById('btn').disabled = false; }
+    catch (e) { say('Ошибка: ' + e, 'err'); btn.disabled = false; bye.disabled = true; }
   });
+  bye.addEventListener('click', disconnect);
 })();
 </script>
 </body>

--- a/static/style.css
+++ b/static/style.css
@@ -1,7 +1,7 @@
 body {
-  font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif;
-  background: linear-gradient(135deg, #091921, #000);
-  color: #fff;
+  font-family: Helvetica, Arial, sans-serif;
+  background: #36393f;
+  color: #dcddde;
   display: flex;
   align-items: center;
   justify-content: center;
@@ -9,24 +9,29 @@ body {
   margin: 0;
 }
 .card {
-  background: rgba(255, 255, 255, 0.1);
-  border-radius: 16px;
+  background: #2f3136;
+  border-radius: 8px;
   padding: 24px;
-  backdrop-filter: blur(12px);
-  box-shadow: 0 0 20px rgba(0, 255, 255, 0.4);
+  box-shadow: 0 2px 10px rgba(0, 0, 0, 0.2);
   max-width: 720px;
   width: 100%;
 }
 button {
-  padding: 10px 16px;
-  border-radius: 10px;
-  border: 1px solid rgba(0,255,255,0.6);
-  background: rgba(0,0,0,0.3);
-  color: #0ff;
+  padding: 8px 16px;
+  border-radius: 4px;
+  border: none;
   cursor: pointer;
 }
+button.primary {
+  background: #5865f2;
+  color: #fff;
+}
+button.danger {
+  background: #ed4245;
+  color: #fff;
+}
 button:disabled {
-  opacity: 0.6;
+  opacity: 0.5;
   cursor: default;
 }
 .row { margin: 10px 0; }
@@ -34,11 +39,14 @@ button:disabled {
 label { margin-right: 12px; }
 input[type="text"] {
   padding: 8px 12px;
-  border-radius: 8px;
-  border: 1px solid rgba(0,255,255,0.6);
-  background: rgba(0,0,0,0.3);
-  color: #0ff;
+  border-radius: 4px;
+  border: none;
+  background: #40444b;
+  color: #dcddde;
 }
 input[type="range"] {
   width: 120px;
+}
+input[type="checkbox"] {
+  accent-color: #5865f2;
 }


### PR DESCRIPTION
## Summary
- restyle browser UI with Discord-inspired dark theme and accent colors
- add disconnect button and cleanup logic for calls

## Testing
- `python -m py_compile async_runner.py core.py gui.py main.py tunnel.py`


------
https://chatgpt.com/codex/tasks/task_e_68a62c16d9f4832788500c5b95d68f3b