### PR TITLE
feat: allow selecting audio output device

### DIFF
--- a/static/index.html
+++ b/static/index.html
@@ -41,6 +41,11 @@
         <button id="settings" class="btn subtle" title="Сетевые настройки (STUN)" aria-pressed="false">⚙︎</button>
       </div>
 
+      <label class="stack">
+        <span>Выход звука:</span>
+        <select id="audio-output" class="input"></select>
+      </label>
+
       <!-- Панель статуса (плашки) -->
       <div class="statusbar pretty" id="statusbar">
         <div class="token-pill" title="Токен комнаты">


### PR DESCRIPTION
## Summary
- add dropdown to choose audio output device
- route remote audio through selected speaker, allowing earpiece use on phones

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `node --check static/app.js`


------
https://chatgpt.com/codex/tasks/task_e_68a720df26ec8327a90e21891e789a45