### PR TITLE
feat: add Kotlin Android client prototype

### DIFF
--- a/AndroidCall/README.md
+++ b/AndroidCall/README.md
@@ -1,0 +1,20 @@
+# AndroidCall
+
+Experimental native Android client for **Secret-Call** server. Written in Kotlin and uses the same WebRTC and WebSocket signalling protocol as the web frontend.
+
+## Features
+- Join and leave audio rooms via the existing `/ws` endpoint.
+- Peer-to-peer audio using `org.webrtc` library.
+- Minimal UI with name/token fields and join/leave button.
+
+> **Note:** This is a basic implementation and does not yet include chat UI, roster display, emoji picker, or audio controls. Those parts of the web app remain TODO.
+
+## Building
+Requires Android Studio/Gradle with Android SDK 24+.
+
+```bash
+cd AndroidCall
+./gradlew assembleDebug
+```
+
+When running on an Android emulator the app expects the Secret-Call server to be available at `http://10.0.2.2:8790`.

--- a/AndroidCall/app/build.gradle.kts
+++ b/AndroidCall/app/build.gradle.kts
@@ -1,0 +1,37 @@
+plugins {
+    id("com.android.application")
+    id("org.jetbrains.kotlin.android")
+}
+
+android {
+    namespace = "com.example.androidcall"
+    compileSdk = 34
+
+    defaultConfig {
+        applicationId = "com.example.androidcall"
+        minSdk = 24
+        targetSdk = 34
+        versionCode = 1
+        versionName = "1.0"
+    }
+
+    buildFeatures {
+        viewBinding = true
+    }
+
+    compileOptions {
+        sourceCompatibility = JavaVersion.VERSION_17
+        targetCompatibility = JavaVersion.VERSION_17
+    }
+    kotlinOptions {
+        jvmTarget = "17"
+    }
+}
+
+dependencies {
+    implementation("androidx.core:core-ktx:1.12.0")
+    implementation("androidx.appcompat:appcompat:1.6.1")
+    implementation("com.google.android.material:material:1.11.0")
+    implementation("org.webrtc:google-webrtc:1.0.32006")
+    implementation("com.squareup.okhttp3:okhttp:4.12.0")
+}

--- a/AndroidCall/app/src/main/AndroidManifest.xml
+++ b/AndroidCall/app/src/main/AndroidManifest.xml
@@ -1,0 +1,19 @@
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
+    <uses-permission android:name="android.permission.INTERNET" />
+    <uses-permission android:name="android.permission.RECORD_AUDIO" />
+
+    <application
+        android:allowBackup="true"
+        android:icon="@mipmap/ic_launcher"
+        android:label="@string/app_name"
+        android:roundIcon="@mipmap/ic_launcher_round"
+        android:supportsRtl="true"
+        android:theme="@style/Theme.AndroidCall">
+        <activity android:name=".MainActivity">
+            <intent-filter>
+                <action android:name="android.intent.action.MAIN" />
+                <category android:name="android.intent.category.LAUNCHER" />
+            </intent-filter>
+        </activity>
+    </application>
+</manifest>

--- a/AndroidCall/app/src/main/java/com/example/androidcall/MainActivity.kt
+++ b/AndroidCall/app/src/main/java/com/example/androidcall/MainActivity.kt
@@ -1,0 +1,93 @@
+package com.example.androidcall
+
+import android.Manifest
+import android.content.pm.PackageManager
+import android.os.Bundle
+import androidx.activity.result.contract.ActivityResultContracts
+import androidx.appcompat.app.AppCompatActivity
+import androidx.core.content.ContextCompat
+import com.example.androidcall.databinding.ActivityMainBinding
+import org.webrtc.IceCandidate
+
+class MainActivity : AppCompatActivity(), SignalingClient.Listener {
+    private lateinit var binding: ActivityMainBinding
+    private var signaling: SignalingClient? = null
+    private var rtc: WebRtcClient? = null
+    private var joined = false
+
+    private val requestPermission = registerForActivityResult(
+        ActivityResultContracts.RequestPermission()
+    ) { granted ->
+        if (granted) startJoin() else binding.statusView.text = "Microphone denied"
+    }
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        binding = ActivityMainBinding.inflate(layoutInflater)
+        setContentView(binding.root)
+
+        binding.joinLeaveButton.setOnClickListener {
+            if (!joined) checkPermsAndJoin() else leave()
+        }
+    }
+
+    private fun checkPermsAndJoin() {
+        when {
+            ContextCompat.checkSelfPermission(this, Manifest.permission.RECORD_AUDIO) == PackageManager.PERMISSION_GRANTED -> startJoin()
+            else -> requestPermission.launch(Manifest.permission.RECORD_AUDIO)
+        }
+    }
+
+    private fun startJoin() {
+        val name = binding.nameInput.text.toString().trim()
+        val token = binding.tokenInput.text.toString().trim()
+        if (name.isEmpty() || token.isEmpty()) {
+            binding.statusView.text = "Name and token required"
+            return
+        }
+        val server = "http://10.0.2.2:8790" // emulator -> host
+        signaling = SignalingClient(server, token, this)
+        rtc = WebRtcClient(this, signaling!!)
+        rtc?.startLocalAudio()
+        signaling?.connect()
+        signaling?.sendName(name)
+        binding.statusView.text = "Joining..."
+        joined = true
+        binding.joinLeaveButton.setText(R.string.leave)
+    }
+
+    private fun leave() {
+        joined = false
+        signaling?.close(); signaling = null
+        rtc?.close(); rtc = null
+        binding.joinLeaveButton.setText(R.string.join)
+        binding.statusView.text = "Left"
+    }
+
+    // SignalingClient.Listener
+    override fun onHello(id: String, roster: List<String>) {
+        rtc?.setSelfId(id)
+        binding.statusView.text = "Connected"
+        roster.forEach { if (it != id) rtc?.maybeCall(it) }
+    }
+
+    override fun onPeerJoined(id: String) {
+        rtc?.maybeCall(id)
+    }
+
+    override fun onPeerLeft(id: String) {
+        rtc?.removePeer(id)
+    }
+
+    override fun onOffer(from: String, sdp: String) {
+        rtc?.onOffer(from, sdp)
+    }
+
+    override fun onAnswer(from: String, sdp: String) {
+        rtc?.onAnswer(from, sdp)
+    }
+
+    override fun onIceCandidate(from: String, candidate: IceCandidate?) {
+        rtc?.onIceCandidate(from, candidate)
+    }
+}

--- a/AndroidCall/app/src/main/java/com/example/androidcall/SignalingClient.kt
+++ b/AndroidCall/app/src/main/java/com/example/androidcall/SignalingClient.kt
@@ -1,0 +1,138 @@
+package com.example.androidcall
+
+import android.util.Log
+import okhttp3.OkHttpClient
+import okhttp3.Request
+import okhttp3.WebSocket
+import okhttp3.WebSocketListener
+import org.json.JSONObject
+import java.util.concurrent.TimeUnit
+import org.webrtc.IceCandidate
+
+class SignalingClient(
+    private val baseUrl: String,
+    private val token: String,
+    private val listener: Listener
+) {
+    private val client = OkHttpClient.Builder()
+        .pingInterval(10, TimeUnit.SECONDS)
+        .build()
+    private var ws: WebSocket? = null
+
+    fun connect() {
+        val scheme = if (baseUrl.startsWith("https")) "wss" else "ws"
+        val url = baseUrl.replaceFirst(Regex("^https?"), scheme) + "/ws?t=" + token
+        val req = Request.Builder()
+            .url(url)
+            .addHeader("Sec-WebSocket-Protocol", "token.$token")
+            .build()
+        ws = client.newWebSocket(req, socketListener)
+    }
+
+    fun sendName(name: String) {
+        val obj = JSONObject()
+        obj.put("type", "name")
+        obj.put("name", name)
+        ws?.send(obj.toString())
+    }
+
+    fun sendOffer(to: String, sdp: String) {
+        val obj = JSONObject()
+        obj.put("type", "offer")
+        obj.put("to", to)
+        obj.put("sdp", sdp)
+        obj.put("sdpType", "offer")
+        ws?.send(obj.toString())
+    }
+
+    fun sendAnswer(to: String, sdp: String) {
+        val obj = JSONObject()
+        obj.put("type", "answer")
+        obj.put("to", to)
+        obj.put("sdp", sdp)
+        obj.put("sdpType", "answer")
+        ws?.send(obj.toString())
+    }
+
+    fun sendIce(to: String, candidate: IceCandidate?) {
+        val obj = JSONObject()
+        obj.put("type", "ice")
+        obj.put("to", to)
+        if (candidate != null) {
+            val c = JSONObject()
+            c.put("candidate", candidate.sdp)
+            c.put("sdpMid", candidate.sdpMid)
+            c.put("sdpMLineIndex", candidate.sdpMLineIndex)
+            obj.put("candidate", c)
+        } else {
+            obj.put("candidate", JSONObject.NULL)
+        }
+        ws?.send(obj.toString())
+    }
+
+    fun close() {
+        ws?.close(4005, "user left")
+        ws = null
+    }
+
+    private val socketListener = object : WebSocketListener() {
+        override fun onOpen(webSocket: WebSocket, response: okhttp3.Response) {
+            Log.d("Signaling", "WebSocket open")
+        }
+
+        override fun onMessage(webSocket: WebSocket, text: String) {
+            try {
+                val m = JSONObject(text)
+                when (m.getString("type")) {
+                    "hello" -> {
+                        val id = m.getString("id")
+                        val rosterArr = m.optJSONArray("roster")
+                        val roster = mutableListOf<String>()
+                        if (rosterArr != null) {
+                            for (i in 0 until rosterArr.length()) {
+                                roster.add(rosterArr.getString(i))
+                            }
+                        }
+                        listener.onHello(id, roster)
+                    }
+                    "peer-joined" -> listener.onPeerJoined(m.getString("id"))
+                    "peer-left" -> listener.onPeerLeft(m.getString("id"))
+                    "offer" -> listener.onOffer(m.getString("from"), m.getString("sdp"))
+                    "answer" -> listener.onAnswer(m.getString("from"), m.getString("sdp"))
+                    "ice" -> {
+                        val c = m.optJSONObject("candidate")
+                        val cand = if (c != null) {
+                            IceCandidate(
+                                c.optString("sdpMid"),
+                                c.optInt("sdpMLineIndex"),
+                                c.optString("candidate")
+                            )
+                        } else null
+                        listener.onIceCandidate(m.getString("from"), cand)
+                    }
+                    "full" -> listener.onFull()
+                    "browser-only" -> listener.onBrowserOnly()
+                    "chat" -> listener.onChat(m)
+                }
+            } catch (e: Exception) {
+                Log.e("Signaling", "parse", e)
+            }
+        }
+
+        override fun onFailure(webSocket: WebSocket, t: Throwable, response: okhttp3.Response?) {
+            Log.e("Signaling", "failure", t)
+        }
+    }
+
+    interface Listener {
+        fun onHello(id: String, roster: List<String>)
+        fun onPeerJoined(id: String)
+        fun onPeerLeft(id: String)
+        fun onOffer(from: String, sdp: String)
+        fun onAnswer(from: String, sdp: String)
+        fun onIceCandidate(from: String, candidate: IceCandidate?)
+        fun onFull() {}
+        fun onBrowserOnly() {}
+        fun onChat(obj: JSONObject) {}
+    }
+}

--- a/AndroidCall/app/src/main/java/com/example/androidcall/WebRtcClient.kt
+++ b/AndroidCall/app/src/main/java/com/example/androidcall/WebRtcClient.kt
@@ -1,0 +1,112 @@
+package com.example.androidcall
+
+import android.content.Context
+import org.webrtc.*
+
+class WebRtcClient(
+    private val context: Context,
+    private val signaling: SignalingClient
+) {
+    private val factory: PeerConnectionFactory
+    private var localStream: MediaStream? = null
+    private val pcs = mutableMapOf<String, PeerConnection>()
+    private var myId: String? = null
+
+    init {
+        val options = PeerConnectionFactory.InitializationOptions.builder(context).createInitializationOptions()
+        PeerConnectionFactory.initialize(options)
+        factory = PeerConnectionFactory.builder().createPeerConnectionFactory()
+    }
+
+    fun setSelfId(id: String) { myId = id }
+
+    fun startLocalAudio() {
+        val audioSource = factory.createAudioSource(MediaConstraints())
+        val audioTrack = factory.createAudioTrack("mic", audioSource)
+        localStream = factory.createLocalMediaStream("stream").apply {
+            addTrack(audioTrack)
+        }
+    }
+
+    fun maybeCall(remoteId: String) {
+        val self = myId ?: return
+        if (self >= remoteId) return
+        val pc = pcs[remoteId] ?: createPeer(remoteId)
+        pc.createOffer(object: SdpObserverAdapter() {
+            override fun onCreateSuccess(desc: SessionDescription) {
+                pc.setLocalDescription(SdpObserverAdapter(), desc)
+                signaling.sendOffer(remoteId, desc.description)
+            }
+        }, MediaConstraints())
+    }
+
+    private fun createPeer(remoteId: String): PeerConnection {
+        val config = PeerConnection.RTCConfiguration(emptyList())
+        val pc = factory.createPeerConnection(config, object: PeerConnectionObserverAdapter() {
+            override fun onIceCandidate(candidate: IceCandidate) {
+                signaling.sendIce(remoteId, candidate)
+            }
+
+            override fun onAddStream(stream: MediaStream) {
+                // TODO: attach stream to audio output
+            }
+        }) ?: throw IllegalStateException("pc null")
+        localStream?.let { pc.addStream(it) }
+        pcs[remoteId] = pc
+        return pc
+    }
+
+    fun onOffer(from: String, sdp: String) {
+        val pc = pcs[from] ?: createPeer(from)
+        pc.setRemoteDescription(SdpObserverAdapter(), SessionDescription(SessionDescription.Type.OFFER, sdp))
+        pc.createAnswer(object: SdpObserverAdapter() {
+            override fun onCreateSuccess(desc: SessionDescription) {
+                pc.setLocalDescription(SdpObserverAdapter(), desc)
+                signaling.sendAnswer(from, desc.description)
+            }
+        }, MediaConstraints())
+    }
+
+    fun onAnswer(from: String, sdp: String) {
+        pcs[from]?.setRemoteDescription(SdpObserverAdapter(), SessionDescription(SessionDescription.Type.ANSWER, sdp))
+    }
+
+    fun onIceCandidate(from: String, candidate: IceCandidate?) {
+        if (candidate != null) pcs[from]?.addIceCandidate(candidate)
+    }
+
+    fun removePeer(id: String) {
+        pcs.remove(id)?.dispose()
+    }
+
+    fun close() {
+        pcs.values.forEach { it.dispose() }
+        pcs.clear()
+        localStream?.let {
+            it.audioTracks.forEach { t -> t.dispose() }
+            it.dispose()
+        }
+        factory.dispose()
+    }
+}
+
+open class SdpObserverAdapter : SdpObserver {
+    override fun onCreateSuccess(sdp: SessionDescription) {}
+    override fun onSetSuccess() {}
+    override fun onCreateFailure(p0: String?) {}
+    override fun onSetFailure(p0: String?) {}
+}
+
+open class PeerConnectionObserverAdapter : PeerConnection.Observer {
+    override fun onSignalingChange(p0: PeerConnection.SignalingState?) {}
+    override fun onIceConnectionChange(p0: PeerConnection.IceConnectionState?) {}
+    override fun onIceConnectionReceivingChange(p0: Boolean) {}
+    override fun onIceGatheringChange(p0: PeerConnection.IceGatheringState?) {}
+    override fun onIceCandidate(p0: IceCandidate) {}
+    override fun onIceCandidatesRemoved(p0: Array<out IceCandidate>?) {}
+    override fun onAddStream(p0: MediaStream) {}
+    override fun onRemoveStream(p0: MediaStream) {}
+    override fun onDataChannel(p0: DataChannel?) {}
+    override fun onRenegotiationNeeded() {}
+    override fun onAddTrack(p0: RtpReceiver?, p1: Array<out MediaStream>?) {}
+}

--- a/AndroidCall/app/src/main/res/layout/activity_main.xml
+++ b/AndroidCall/app/src/main/res/layout/activity_main.xml
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:orientation="vertical"
+    android:padding="16dp">
+
+    <EditText
+        android:id="@+id/nameInput"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:hint="@string/name_hint" />
+
+    <EditText
+        android:id="@+id/tokenInput"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:hint="@string/token_hint"
+        android:layout_marginTop="8dp" />
+
+    <Button
+        android:id="@+id/joinLeaveButton"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:text="@string/join"
+        android:layout_marginTop="16dp" />
+
+    <TextView
+        android:id="@+id/statusView"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:text=""
+        android:layout_marginTop="16dp" />
+
+</LinearLayout>

--- a/AndroidCall/app/src/main/res/values/strings.xml
+++ b/AndroidCall/app/src/main/res/values/strings.xml
@@ -1,0 +1,7 @@
+<resources>
+    <string name="app_name">AndroidCall</string>
+    <string name="join">Join</string>
+    <string name="leave">Leave</string>
+    <string name="name_hint">Name</string>
+    <string name="token_hint">Token</string>
+</resources>

--- a/AndroidCall/build.gradle.kts
+++ b/AndroidCall/build.gradle.kts
@@ -1,0 +1,4 @@
+plugins {
+    id("com.android.application") version "8.1.0" apply false
+    id("org.jetbrains.kotlin.android") version "1.8.22" apply false
+}

--- a/AndroidCall/settings.gradle.kts
+++ b/AndroidCall/settings.gradle.kts
@@ -1,0 +1,2 @@
+rootProject.name = "AndroidCall"
+include(":app")


### PR DESCRIPTION
## Summary
- add AndroidCall Kotlin project with minimal WebRTC client
- implement WebSocket signaling and peer connections
- provide basic UI with join/leave and token fields

## Testing
- `./gradlew tasks` *(fails: No such file or directory)*
- `gradle tasks` *(runs but environment incomplete)*

------
https://chatgpt.com/codex/tasks/task_e_68a7284a55a48327ab2cb27510829005